### PR TITLE
Fix json according to RFC 8259

### DIFF
--- a/server-list.json
+++ b/server-list.json
@@ -17,7 +17,7 @@
 			"Name": "Comfy",
 			"Bans": "https://getcomfy.eu/api/v1/ban/get/all",
 			"Website": "https://getcomfy.eu/",
-			"Discord": "https://getcomfy.eu/discord",
+			"Discord": "https://getcomfy.eu/discord"
 		},
 		{
 			"Name": "RedMew",


### PR DESCRIPTION
Removing the comma on line 20 (in Comfy) ensures compatibility with RFC 8259

https://jsonformatter.curiousconcept.com/

![image](https://user-images.githubusercontent.com/61465776/210156608-42317cd4-59c9-4a89-93da-3af907d34f90.png)
